### PR TITLE
Add missing `gf180mcu_fd_bd_sram` to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,13 @@
 	branch = main
 	shallow = true
 
+# gf180mcu_fd_bd_sram
+[submodule "libraries/gf180mcu_fd_bd_sram/latest"]
+	path = libraries/gf180mcu_fd_bd_sram/latest
+	url = https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_bd_sram.git
+	branch = main
+	shallow = true
+
 # gf180mcu_fd_io
 [submodule "libraries/gf180mcu_fd_io/latest"]
 	path = libraries/gf180mcu_fd_io/latest


### PR DESCRIPTION
Fixes #13.

```
git submodule update --init --recursive
fatal: No url found for submodule path 'libraries/gf180mcu_fd_bd_sram/latest' in .gitmodules
```

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>