### PR TITLE
Enable parallel doc build.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ TOP_DIR := $(realpath $(DOCS_DIR)/..)
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS     ?= -j auto
 SPHINXBUILD     = sphinx-build
 SPHINXAUTOBUILD = sphinx-autobuild
 SPHINXPROJ      = gf180mcuPDK
@@ -37,4 +37,3 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	


### PR DESCRIPTION
Makes building the documentation significantly faster on big machines.

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>