### PR TITLE
Enable additional PDF output for readthedocs.io

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,10 +14,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: gf180mu-pdk-docs
-channels:
-- defaults
-dependencies:
-- python>=3.8
-- pip:
-  - -r docs/requirements.txt
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt
+
+submodules:
+  include:
+  - third_party/open-source-pdks
+  recursive: false
+
+formats:
+  - pdf


### PR DESCRIPTION
Enable as per proposed here: https://github.com/google/gf180mcu-pdk/pull/79#issuecomment-1269144168
Following ```readthedocs```:  https://docs.readthedocs.io/en/stable/config-file/v1.html#formats

~Cristian.