### PR TITLE
readthedocs: include all submodules

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,9 +24,7 @@ python:
   - requirements: docs/requirements.txt
 
 submodules:
-  include:
-  - third_party/open-source-pdks
-  recursive: false
+  include: all
 
 formats:
   - pdf


### PR DESCRIPTION
Signed-off-by: Johan Euphrosine <proppy@google.com>

Fixes #82

TEST=https://gf180mcu-pdk--83.org.readthedocs.build/en/83/digital/standard_cells/gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_20.html