### PR TITLE
Fix PDF generation failure on blank SVG files.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,8 +193,11 @@ latex_elements = {
                  r'\DeclareUnicodeCharacter{2220}{\ensuremath{\angle}}' +
                  r'\DeclareUnicodeCharacter{2227}{\ensuremath{\wedge}}' +
                  r'\DeclareUnicodeCharacter{25A1}{\ensuremath{\Box}}' +
-                 r'\DeclareUnicodeCharacter{F06D}{\ensuremath{\mu}}'
+                 r'\DeclareUnicodeCharacter{F06D}{\ensuremath{\Box}}' +
+                 r'\DeclareUnicodeCharacter{F057}{\ensuremath{\otimes}}'
 }
+
+image_converter_args=["-quiet"]
 
 def setup(app):
     app.add_css_file('GF_theme.css')


### PR DESCRIPTION
In continuation of #82 & #83 this fix broken PDF generation [as of last log](https://readthedocs.org/projects/gf180mcu-pdk/builds/18381655/).

- Silently discards blank SVG conversions (there are many blanks).
- Additional latex UTF-8 char mappings to build full documentation.

Cc @proppy 

Thanks,
~Cristian.
