### PR TITLE
Use sphinx-svg2pdfconverter as SVG handler instead.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,5 @@ latex_elements = {
                  r'\DeclareUnicodeCharacter{F057}{\ensuremath{\otimes}}'
 }
 
-image_converter_args=["-quiet"]
-
 def setup(app):
     app.add_css_file('GF_theme.css')

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@ docutils
 sphinx
 sphinx-autobuild
 sphinxcontrib-wavedrom
+sphinxcontrib-svg2pdfconverter
 


### PR DESCRIPTION

Again, fix the readthedocs PDF generation [latest failure](https://readthedocs.org/projects/gf180mcu-pdk/builds/18384992).
All pass on local ```make latexpdf``` with inkscape installed.

* Use ```sphinxcontrib-svg2pdfconverter``` that picks up ```inkscape/rsvg-convert``` [instead of](https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html) ```imagemagick```  
* With ```inkscape``` such conversion errors like ```must specify image size``` will go away on blank SVG drawings.

I hope it is last, also hope that readthedocs's docker image are smart to have ```inkscape``` along with ```imagemagick``` deps.

Cc @proppy , lets see now.
