### PR TITLE
doc: switch to sphinxcontrib.rsvgconverter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx.ext.imgconverter',
+    'sphinxcontrib.rsvgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Apparently the pdf build failure (see https://github.com/google/gf180mcu-pdk/issues/82#issuecomment-1284785504) makes the final RTD documentation push fails.

Fixes #82 (hopefully)

Also enabled `PDF build` in https://readthedocs.org/dashboard/gf180mcu-pdk/advanced/
![image](https://user-images.githubusercontent.com/5268/196839433-cb47c25b-6397-41fd-a042-6202cb3ba815.png)

TEST=https://gf180mcu-pdk--87.org.readthedocs.build/en/87/digital/Digital.html

/cc @cbalint13 @mkkassem 